### PR TITLE
fix: add missing subpackages to setuptools packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license = "GPL-3.0-or-later"
 Homepage = "https://github.com/polio-nanopore/piranha"
 
 [tool.setuptools]
-packages = ["piranha", "piranha.scripts"]
+packages = ["piranha", "piranha.scripts", "piranha.input_parsing", "piranha.analysis", "piranha.utils", "piranha.data", "piranha.report"]
 
 [tool.setuptools.package-data]
 myModule = ["data/*"]


### PR DESCRIPTION
Fixes #290 - AttributeError after install

The pyproject.toml was missing several subpackages (input_parsing, analysis, utils, data, report) which caused AttributeError during import.